### PR TITLE
feat(studio): Add Apollo sandbox for API

### DIFF
--- a/docs/api-intro.md
+++ b/docs/api-intro.md
@@ -2,6 +2,8 @@
 sidebar_position: 5
 ---
 
+import ApolloSandboxComponent from '@site/src/components/ApolloSandboxComponent';
+
 # API Overview
 
 Zapper Protocol will be offering a GraphQL API for developers to access interpreted data. This API will be the primary way for developers to access onchain data from Zapper Protocol.
@@ -10,6 +12,14 @@ Zapper Protocol will be offering a GraphQL API for developers to access interpre
 You can access Zapper's existing REST API [here](https://studio.zapper.xyz/docs/apis/getting-started), which supports portfolio tracking capabilities.
 Zapper Protocol's GraphQL API will be released in Q4 2024, at which time users of the REST API will be asked to migrate.
 :::
+
+---
+
+## API Sandbox
+
+To test the Zapper API, you can use the sandbox below:
+
+<ApolloSandboxComponent />
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 	},
 	"dependencies": {
 		"@apollo/explorer": "^3.7.0",
-		"@apollo/sandbox": "^2.7.0",
 		"@docusaurus/core": "3.4.0",
 		"@docusaurus/preset-classic": "3.4.0",
 		"@docusaurus/theme-classic": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"dev": "docusaurus start"
 	},
 	"dependencies": {
+		"@apollo/sandbox": "^2.7.0",
 		"@docusaurus/core": "3.4.0",
 		"@docusaurus/preset-classic": "3.4.0",
 		"@docusaurus/theme-classic": "^3.4.0",
@@ -38,7 +39,11 @@
 		"typescript": "~5.2.2"
 	},
 	"browserslist": {
-		"production": [">0.5%", "not dead", "not op_mini all"],
+		"production": [
+			">0.5%",
+			"not dead",
+			"not op_mini all"
+		],
 		"development": [
 			"last 3 chrome version",
 			"last 3 firefox version",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"dev": "docusaurus start"
 	},
 	"dependencies": {
+		"@apollo/explorer": "^3.7.0",
 		"@apollo/sandbox": "^2.7.0",
 		"@docusaurus/core": "3.4.0",
 		"@docusaurus/preset-classic": "3.4.0",
@@ -30,7 +31,8 @@
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0",
 		"redoc": "^2.1.4",
-		"sass": "^1.77.2"
+		"sass": "^1.77.2",
+		"use-deep-compare-effect": "^1.8.1"
 	},
 	"devDependencies": {
 		"@docusaurus/module-type-aliases": "3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   '@apollo/explorer':
     specifier: ^3.7.0
     version: 3.7.0(graphql@16.9.0)(react-dom@18.0.0)(react@18.0.0)(use-deep-compare-effect@1.8.1)
-  '@apollo/sandbox':
-    specifier: ^2.7.0
-    version: 2.7.0(graphql@16.9.0)(react-dom@18.0.0)(react@18.0.0)
   '@docusaurus/core':
     specifier: 3.4.0
     version: 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.0.0)(react@18.0.0)(typescript@5.2.2)
@@ -239,31 +236,6 @@ packages:
       react-dom: 18.0.0(react@18.0.0)
       subscriptions-transport-ws: 0.11.0(graphql@16.9.0)
       use-deep-compare-effect: 1.8.1(react@18.0.0)
-      whatwg-mimetype: 3.0.0
-      zen-observable-ts: 1.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - graphql
-      - utf-8-validate
-    dev: false
-
-  /@apollo/sandbox@2.7.0(graphql@16.9.0)(react-dom@18.0.0)(react@18.0.0):
-    resolution: {integrity: sha512-17Xvdj0zSCFE1TPNRtfsZ7/dsgOoiFZ7rFdM+X9ca523PG+qQbZ1x2nvGvrHmb2UzPb66RvOVJC+oNC072c17Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@types/whatwg-mimetype': 3.0.2
-      eventemitter3: 3.1.0
-      graphql-ws: 5.16.0(graphql@16.9.0)
-      react: 18.0.0
-      react-dom: 18.0.0(react@18.0.0)
-      subscriptions-transport-ws: 0.11.0(graphql@16.9.0)
       whatwg-mimetype: 3.0.0
       zen-observable-ts: 1.1.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@apollo/explorer':
+    specifier: ^3.7.0
+    version: 3.7.0(graphql@16.9.0)(react-dom@18.0.0)(react@18.0.0)(use-deep-compare-effect@1.8.1)
   '@apollo/sandbox':
     specifier: ^2.7.0
     version: 2.7.0(graphql@16.9.0)(react-dom@18.0.0)(react@18.0.0)
@@ -50,6 +53,9 @@ dependencies:
   sass:
     specifier: ^1.77.2
     version: 1.77.2
+  use-deep-compare-effect:
+    specifier: ^1.8.1
+    version: 1.8.1(react@18.0.0)
 
 devDependencies:
   '@docusaurus/module-type-aliases':
@@ -211,6 +217,34 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+    dev: false
+
+  /@apollo/explorer@3.7.0(graphql@16.9.0)(react-dom@18.0.0)(react@18.0.0)(use-deep-compare-effect@1.8.1):
+    resolution: {integrity: sha512-7Y6JuYSK2Or5bctRmG/hrccj5b7+gAj58XZBewRzvpIDS6NPoN67fcltOortstVkYyeIscR6bTca8oCsAMozgA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      use-deep-compare-effect: ^1.8.1
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      use-deep-compare-effect:
+        optional: true
+    dependencies:
+      '@types/whatwg-mimetype': 3.0.2
+      graphql-ws: 5.16.0(graphql@16.9.0)
+      react: 18.0.0
+      react-dom: 18.0.0(react@18.0.0)
+      subscriptions-transport-ws: 0.11.0(graphql@16.9.0)
+      use-deep-compare-effect: 1.8.1(react@18.0.0)
+      whatwg-mimetype: 3.0.0
+      zen-observable-ts: 1.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - graphql
+      - utf-8-validate
     dev: false
 
   /@apollo/sandbox@2.7.0(graphql@16.9.0)(react-dom@18.0.0)(react@18.0.0):
@@ -10301,6 +10335,17 @@ packages:
 
   /url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+    dev: false
+
+  /use-deep-compare-effect@1.8.1(react@18.0.0):
+    resolution: {integrity: sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13'
+    dependencies:
+      '@babel/runtime': 7.22.11
+      dequal: 2.0.3
+      react: 18.0.0
     dev: false
 
   /util-deprecate@1.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@apollo/sandbox':
+    specifier: ^2.7.0
+    version: 2.7.0(graphql@16.9.0)(react-dom@18.0.0)(react@18.0.0)
   '@docusaurus/core':
     specifier: 3.4.0
     version: 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.0.0)(react@18.0.0)(typescript@5.2.2)
@@ -208,6 +211,31 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+    dev: false
+
+  /@apollo/sandbox@2.7.0(graphql@16.9.0)(react-dom@18.0.0)(react@18.0.0):
+    resolution: {integrity: sha512-17Xvdj0zSCFE1TPNRtfsZ7/dsgOoiFZ7rFdM+X9ca523PG+qQbZ1x2nvGvrHmb2UzPb66RvOVJC+oNC072c17Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@types/whatwg-mimetype': 3.0.2
+      eventemitter3: 3.1.0
+      graphql-ws: 5.16.0(graphql@16.9.0)
+      react: 18.0.0
+      react-dom: 18.0.0(react@18.0.0)
+      subscriptions-transport-ws: 0.11.0(graphql@16.9.0)
+      whatwg-mimetype: 3.0.0
+      zen-observable-ts: 1.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - graphql
+      - utf-8-validate
     dev: false
 
   /@babel/code-frame@7.24.2:
@@ -3095,6 +3123,10 @@ packages:
   /@types/unist@3.0.2:
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
 
+  /@types/whatwg-mimetype@3.0.2:
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+    dev: false
+
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
@@ -3109,6 +3141,10 @@ packages:
     resolution: {integrity: sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==}
     dependencies:
       '@types/yargs-parser': 21.0.0
+    dev: false
+
+  /@types/zen-observable@0.8.3:
+    resolution: {integrity: sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==}
     dev: false
 
   /@ungap/structured-clone@1.2.0:
@@ -3522,6 +3558,10 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /backo2@1.0.2:
+    resolution: {integrity: sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==}
     dev: false
 
   /bail@2.0.2:
@@ -5155,6 +5195,10 @@ packages:
       require-like: 0.1.2
     dev: false
 
+  /eventemitter3@3.1.0:
+    resolution: {integrity: sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==}
+    dev: false
+
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
     dev: false
@@ -5625,6 +5669,20 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  /graphql-ws@5.16.0(graphql@16.9.0):
+    resolution: {integrity: sha512-Ju2RCU2dQMgSKtArPbEtsK5gNLnsQyTNIo/T7cZNp96niC1x0KdJNZV0TIoilceBPQwfb5itrGl8pkFeOUMl4A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: '>=0.11 <=16'
+    dependencies:
+      graphql: 16.9.0
+    dev: false
+
+  /graphql@16.9.0:
+    resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: false
 
   /gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -6315,6 +6373,10 @@ packages:
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
+
+  /iterall@1.3.0:
+    resolution: {integrity: sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==}
+    dev: false
 
   /jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
@@ -9823,6 +9885,23 @@ packages:
     resolution: {integrity: sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==}
     dev: false
 
+  /subscriptions-transport-ws@0.11.0(graphql@16.9.0):
+    resolution: {integrity: sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==}
+    deprecated: The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md
+    peerDependencies:
+      graphql: ^15.7.2 || ^16.0.0
+    dependencies:
+      backo2: 1.0.2
+      eventemitter3: 3.1.0
+      graphql: 16.9.0
+      iterall: 1.3.0
+      symbol-observable: 1.2.0
+      ws: 7.5.9
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -9883,6 +9962,11 @@ packages:
       yargs: 17.7.2
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /symbol-observable@1.2.0:
+    resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
+    engines: {node: '>=0.10.0'}
     dev: false
 
   /symbol-tree@3.2.4:
@@ -10663,6 +10747,17 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: false
+
+  /zen-observable-ts@1.1.0:
+    resolution: {integrity: sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==}
+    dependencies:
+      '@types/zen-observable': 0.8.3
+      zen-observable: 0.8.15
+    dev: false
+
+  /zen-observable@0.8.15:
+    resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
     dev: false
 
   /zwitch@2.0.4:

--- a/src/components/ApolloSandboxComponent.tsx
+++ b/src/components/ApolloSandboxComponent.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { ApolloExplorer } from '@apollo/explorer/react';
 
 const ApolloSandboxComponent: React.FC = () => {
+  // This is our rate limited, public API key, for free use in the Apollo Sandbox
+  // It is meant to be public
+  const API_KEY = "Basic YWQwMTUyN2UtODEzMy00YTY4LWFkNjctZmJmOGQ5MDQwYWQxOg==";
   const TEST_ADDRESSES = ["0xd8da6bf26964af9d7eed9e03e53415d37aa96045", "0x6f6e75fb472ee39d847d825cc7c9a613e227e261"];
 
   return (
@@ -24,9 +27,11 @@ const ApolloSandboxComponent: React.FC = () => {
         variables: {
           addresses: TEST_ADDRESSES,
         },
-        headers: {},
+        headers: {
+          Authorization: API_KEY,
+        },
         displayOptions: {
-          showHeadersAndEnvVars: true,
+          showHeadersAndEnvVars: false,
           docsPanelState: 'open',
           theme: 'dark',
         },

--- a/src/components/ApolloSandboxComponent.tsx
+++ b/src/components/ApolloSandboxComponent.tsx
@@ -1,12 +1,37 @@
 import React from 'react';
-import { ButtonType, LinkButton } from './LinkButton';
+import { ApolloExplorer } from '@apollo/explorer/react';
 
 const ApolloSandboxComponent: React.FC = () => {
+  const TEST_ADDRESSES = ["0xd8da6bf26964af9d7eed9e03e53415d37aa96045", "0x6f6e75fb472ee39d847d825cc7c9a613e227e261"];
+
   return (
-    <LinkButton
-      type={ButtonType.Primary}
-      buttonCopy="Open Apollo Sandbox"
-      href="https://studio.apollographql.com/sandbox/explorer?endpoint=https://public.zapper.xyz/graphql"
+    <ApolloExplorer
+      graphRef="zapper-public-api@current"
+      persistExplorerState={false}
+      initialState={{
+        document: `query($addresses: [Address!]!) {
+    portfolio(addresses: $addresses) {
+      tokenBalances {
+        address
+        network
+        token {
+          balanceUSD
+        }
+      }
+    }
+  }
+    `,
+        variables: {
+          addresses: TEST_ADDRESSES,
+        },
+        headers: {},
+        displayOptions: {
+          showHeadersAndEnvVars: false,
+          docsPanelState: 'open',
+          theme: 'dark',
+        },
+      }}
+      className="apollo-sandbox"
     />
   );
 };

--- a/src/components/ApolloSandboxComponent.tsx
+++ b/src/components/ApolloSandboxComponent.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ApolloSandbox } from '@apollo/sandbox/react';
+
+const ApolloSandboxComponent: React.FC = () => (
+  <ApolloSandbox
+    initialEndpoint="https://public.zapper.xyz/graphql"
+    initialState={{
+      document: `query($addresses: [Address!]!) {
+  portfolio(addresses: $addresses) {
+    tokenBalances {
+      address
+      network
+      token {
+        balanceUSD
+      }
+    }
+  }
+}
+    `,
+      variables: {
+        addresses: ["0xd8da6bf26964af9d7eed9e03e53415d37aa96045", "0x6f6e75fb472ee39d847d825cc7c9a613e227e261"],
+      },
+    }}
+    className="apollo-sandbox"
+  />
+);
+
+export default ApolloSandboxComponent;

--- a/src/components/ApolloSandboxComponent.tsx
+++ b/src/components/ApolloSandboxComponent.tsx
@@ -26,7 +26,7 @@ const ApolloSandboxComponent: React.FC = () => {
         },
         headers: {},
         displayOptions: {
-          showHeadersAndEnvVars: false,
+          showHeadersAndEnvVars: true,
           docsPanelState: 'open',
           theme: 'dark',
         },

--- a/src/components/ApolloSandboxComponent.tsx
+++ b/src/components/ApolloSandboxComponent.tsx
@@ -1,28 +1,14 @@
 import React from 'react';
-import { ApolloSandbox } from '@apollo/sandbox/react';
+import { ButtonType, LinkButton } from './LinkButton';
 
-const ApolloSandboxComponent: React.FC = () => (
-  <ApolloSandbox
-    initialEndpoint="https://public.zapper.xyz/graphql"
-    initialState={{
-      document: `query($addresses: [Address!]!) {
-  portfolio(addresses: $addresses) {
-    tokenBalances {
-      address
-      network
-      token {
-        balanceUSD
-      }
-    }
-  }
-}
-    `,
-      variables: {
-        addresses: ["0xd8da6bf26964af9d7eed9e03e53415d37aa96045", "0x6f6e75fb472ee39d847d825cc7c9a613e227e261"],
-      },
-    }}
-    className="apollo-sandbox"
-  />
-);
+const ApolloSandboxComponent: React.FC = () => {
+  return (
+    <LinkButton
+      type={ButtonType.Primary}
+      buttonCopy="Open Apollo Sandbox"
+      href="https://studio.apollographql.com/sandbox/explorer?endpoint=https://public.zapper.xyz/graphql"
+    />
+  );
+};
 
 export default ApolloSandboxComponent;

--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "../pages/index.module.scss";
 import Link from "@docusaurus/Link";
 
-enum ButtonType {
+export enum ButtonType {
 	Primary = "primary",
 	Secondary = "secondary",
 }

--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "../pages/index.module.scss";
 import Link from "@docusaurus/Link";
 
-export enum ButtonType {
+enum ButtonType {
 	Primary = "primary",
 	Secondary = "secondary",
 }

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -369,4 +369,9 @@
       display: none !important;
     }
   }
+
+  .apollo-sandbox {
+    height: 600px;
+    overflow: hidden;
+  }
   

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -370,3 +370,8 @@
     }
   }
 
+  .apollo-sandbox {
+    height: 600px;
+    overflow: hidden;
+  }
+  

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -369,9 +369,4 @@
       display: none !important;
     }
   }
-
-  .apollo-sandbox {
-    height: 600px;
-    overflow: hidden;
-  }
   


### PR DESCRIPTION
## Description

This adds a new Apollo sandbox enabling clients to test some requests to the new API, before purchasing some points. It also adds the API key for public use : this key is heavily rate limited, and is meant to be public.
![image](https://github.com/user-attachments/assets/1449a6a5-347d-454e-b2ac-eb02603f71f0)
