### PR TITLE
smol(studio): Styling cleanup

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,9 +1,9 @@
 export function Button(props) {
-  const { children, className, ...rest } = props;
+  const { children, className, height = 'h-10', textSize = 'text-[16px]', ...rest } = props;
 
   return (
     <button
-      className={`button--primary cursor-pointer border-none rounded-lg px-4 display-flex align-items-center h-10 text-[16px] font-semibold opacity-100 hover:opacity-80 transition-all ${className || ''}`}
+      className={`button--primary cursor-pointer border-none rounded-lg px-4 display-flex align-items-center ${height} ${textSize} font-semibold opacity-100 hover:opacity-80 transition-all ${className || ''}`}
       {...rest}
     >
       {children}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -442,3 +442,10 @@ hr {
     display: none !important;
   }
 }
+
+.DocSearch-Hit-content-wrapper {
+  padding: 4px 8px !important;
+}
+.DocSearch-Button-Placeholder, .DocSearch-Button-Keys {
+  display: none !important;
+ }

--- a/src/modules/Dashboard/BuyCredits.tsx
+++ b/src/modules/Dashboard/BuyCredits.tsx
@@ -29,7 +29,7 @@ const CREATE_CHARGE = gql`
 const Toast = ({ message, position }) => {
   return ReactDOM.createPortal(
     <div
-      className="absolute bg-gray-800 text-white p-2 rounded-md text-xs max-w-[200px] whitespace-normal"
+      className="absolute bg-gray-800 text-white p-2 rounded-md text-xs max-w-[200px]"
       style={{
         top: position.top,
         left: position.left + 10,
@@ -61,7 +61,7 @@ const InfoIcon = ({ message }) => {
         onMouseEnter={handleMouseEnter}
         onMouseLeave={() => setShowToast(false)}
       >
-        <Info className="h-3 w-3 text-gray-400" />
+        <Info className="h-3 w-3" />
       </div>
       {showToast && <Toast message={message} position={position} />}
     </div>
@@ -129,8 +129,8 @@ export function BuyCredits() {
   };
 
   const { apiV2PointsRemaining = 0, apiV1PointsRemaining } = data?.apiClientById || {};
-  const displayV2Points = apiV2PointsRemaining <= 0 ? GRACE_PERIOD + apiV2PointsRemaining : apiV2PointsRemaining;
-  const isNegativeBalance = apiV2PointsRemaining <= 0;
+  const displayV2Points = apiV2PointsRemaining < 0 ? GRACE_PERIOD + apiV2PointsRemaining : apiV2PointsRemaining;
+  const isNegativeBalance = apiV2PointsRemaining < 0;
   const disabled = loading || !user;
 
   return (
@@ -139,15 +139,15 @@ export function BuyCredits() {
         <h3>Buy Credits</h3>
         <div className="text-right">
           <p className="flex items-center justify-end gap-1">
-            Credit balance:{' '}
+            Credit balance:
             <span className={`font-bold ${isNegativeBalance ? 'text-yellow-500' : 'text-green-500'}`}>
-              {Number(displayV2Points)}
+              {displayV2Points}
             </span>
             {isNegativeBalance && <InfoIcon message="You are now consuming the free 10 000 credit grant from Zapper" />}
           </p>
           {Number(apiV1PointsRemaining) > 0 && (
             <p className="flex items-center justify-end gap-1">
-              Legacy REST API credits: <span className="font-bold">{Number(apiV1PointsRemaining)}</span>
+              Legacy REST API credits: <span className="font-bold">{apiV1PointsRemaining}</span>
               <InfoIcon message="These credits are still available for use with the legacy REST API" />
             </p>
           )}
@@ -157,10 +157,8 @@ export function BuyCredits() {
       <Card>
         {errorMessage && <p className="text-red-400">{errorMessage}</p>}
 
-        {error && <p className="text-red-400">Error: {error.message}</p>}
-
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="grid grid-cols-2 gap-4 items-center">
+          <div className="grid grid-cols-2 ">
             <div className="space-y-2">
               <label htmlFor="points-input" className="text-sm font-medium">
                 Credit Amount
@@ -188,10 +186,10 @@ export function BuyCredits() {
               <div className="h-10 flex items-center">
                 <div
                   id="cost-display"
-                  className="font-extrabold text-[#A387FF] bg-transparent"
+                  className="font-extrabold text-primary-default bg-transparent"
                   aria-label={`Cost: $${calculateCost(displayPoints)}`}
                 >
-                  USD ${calculateCost(displayPoints)}
+                  USD ${calculateCost(points)}
                 </div>
               </div>
             </div>

--- a/src/modules/Dashboard/BuyCredits.tsx
+++ b/src/modules/Dashboard/BuyCredits.tsx
@@ -196,7 +196,7 @@ export function BuyCredits() {
           </div>
 
           <Button type="submit" variant="primary" disabled={disabled} className="w-full">
-            Buy for USD ${calculateCost(points)}
+            <span className="font-extrabold">Buy for USD ${calculateCost(points)}</span>
           </Button>
         </form>
       </Card>

--- a/src/modules/Dashboard/ConsumptionStats.tsx
+++ b/src/modules/Dashboard/ConsumptionStats.tsx
@@ -31,6 +31,14 @@ interface ConsumptionStat {
   totalCost: number;
 }
 
+const generateColor = (index: number, opacity = 0.7) => {
+  const hue = (index * 137.508) % 360;
+  return {
+    bg: `hsla(${hue}, 70%, 85%, ${opacity})`,
+    border: `hsl(${hue}, 70%, 75%)`,
+  };
+};
+
 const CONSUMPTION_QUERY = gql`
   query GetConsumptionStats($timeFrame: ApiRoundtripStatsTimeFrame!) {
     apiConsumptionStats(timeFrame: $timeFrame) {
@@ -58,17 +66,13 @@ export function ConsumptionStats() {
     data: consumptionData,
     loading: consumptionLoading,
     error: consumptionError,
-  } = useAuthQuery(CONSUMPTION_QUERY, {
-    variables: { timeFrame },
-  });
+  } = useAuthQuery(CONSUMPTION_QUERY, { variables: { timeFrame } });
 
   const {
     data: endpointData,
     loading: endpointLoading,
     error: endpointError,
-  } = useAuthQuery(ENDPOINT_QUERY, {
-    variables: { timeFrame },
-  });
+  } = useAuthQuery(ENDPOINT_QUERY, { variables: { timeFrame } });
 
   const consumptionStats = (consumptionData?.apiConsumptionStats || []) as ConsumptionStat[];
   const endpointStats = (endpointData?.apiConsumptionStatsPerEndpoint || []) as EndpointStat[];
@@ -144,19 +148,10 @@ export function ConsumptionStats() {
   const uniqueDates = Array.from(new Set(endpointStats.map((item) => item.intervalStart))).sort();
   const uniqueEndpoints = Array.from(new Set(endpointStats.map((item) => item.operationName)));
 
-  const colors = [
-    { bg: 'rgba(120,79,254,0.7)', border: 'rgb(193,172,252)' },
-    { bg: 'rgba(118,181,197,0.7)', border: '#8dd8e3' },
-    { bg: 'rgba(255,99,132,0.7)', border: 'rgb(255,99,132)' },
-    { bg: 'rgba(75,192,192,0.7)', border: 'rgb(75,192,192)' },
-    { bg: 'rgba(255,159,64,0.7)', border: 'rgb(255,159,64)' },
-    { bg: 'rgba(153,102,255,0.7)', border: 'rgb(153,102,255)' },
-  ];
-
   const endpointChartData = {
     labels: uniqueDates.map((date) => new Date(date).toLocaleDateString()),
     datasets: uniqueEndpoints.map((endpoint, index) => {
-      const colorIndex = index % colors.length;
+      const color = generateColor(index);
       const data = uniqueDates.map((date) => {
         const dataPoint = endpointStats.find((stat) => stat.intervalStart === date && stat.operationName === endpoint);
         return dataPoint ? dataPoint.requestCount : 0;
@@ -166,8 +161,8 @@ export function ConsumptionStats() {
         label: endpoint,
         data: data,
         fill: false,
-        backgroundColor: colors[colorIndex].bg,
-        borderColor: colors[colorIndex].border,
+        backgroundColor: color.bg,
+        borderColor: color.border,
         borderWidth: 1,
         pointRadius: 1,
         tension: 0.1,

--- a/src/modules/Dashboard/ConsumptionStats.tsx
+++ b/src/modules/Dashboard/ConsumptionStats.tsx
@@ -141,7 +141,6 @@ export function ConsumptionStats() {
     ],
   };
 
-  // Data preparation for the second chart (Endpoints over time)
   const uniqueDates = Array.from(new Set(endpointStats.map((item) => item.intervalStart))).sort();
   const uniqueEndpoints = Array.from(new Set(endpointStats.map((item) => item.operationName)));
 
@@ -188,8 +187,8 @@ export function ConsumptionStats() {
               onClick={() => handleTimeFrameChange(tf)}
               className={`w-full border-none cursor-pointer ${
                 timeFrame === tf
-                  ? 'font-extrabold text-[#A387FF] bg-transparent'
-                  : 'font-medium text-[#A387FF] bg-transparent'
+                  ? 'font-extrabold text-primary-default bg-transparent'
+                  : 'font-medium text-primary-default bg-transparent'
               }`}
             >
               {tf.charAt(0) + tf.slice(1).toLowerCase()}
@@ -200,7 +199,7 @@ export function ConsumptionStats() {
 
       <div className="space-y-8">
         <div>
-          <h3 className="mb-4">Consumption Amount & Cost</h3>
+          <h3>Consumption Amount & Cost</h3>
           <Card>
             {consumptionLoading ? (
               <p>Loading...</p>
@@ -215,7 +214,7 @@ export function ConsumptionStats() {
         </div>
 
         <div>
-          <h3 className="mb-4">Endpoints Queried</h3>
+          <h3>Endpoints Queried</h3>
           <Card>
             {endpointLoading ? (
               <p>Loading...</p>

--- a/src/modules/Dashboard/Note.tsx
+++ b/src/modules/Dashboard/Note.tsx
@@ -1,17 +1,11 @@
-import { gql } from '@apollo/client';
-import { useAuthQuery } from '@site/src/helpers/useAuthQuery';
 import { Card } from '@site/src/components/Card';
-import { Button } from '@site/src/components/Button';
-import { usePrivy } from '@privy-io/react-auth';
-import { Copy, Info } from 'lucide-react';
-import { useState, useEffect } from 'react';
-import styles from '@site/src/pages/index.module.scss';
+import { Info } from 'lucide-react';
 
 export function Note() {
   return (
     <Card>
       <div className="flex items-start gap-3">
-        <Info className="h-5 w-5 text-[#A387FF] mt-0.5 flex-shrink-0" />
+        <Info className="h-5 w-5 text-primary-default flex-shrink-0" />
         <p className="text-sm">
           Welcome to the Zapper Protocol Dashboard. While the API is in beta, each client may query up to 10k credits
           freely, which rounds up to about 1000 requests. Please note that query costs may change during beta.

--- a/src/modules/Dashboard/PaymentHistory.tsx
+++ b/src/modules/Dashboard/PaymentHistory.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client';
-import { Card } from '@site/src/components/Card';
 import { formatDate } from '@site/src/helpers/formatDate';
 import { useAuthQuery } from '@site/src/helpers/useAuthQuery';
 import { Info } from 'lucide-react';

--- a/src/modules/Dashboard/Profile.tsx
+++ b/src/modules/Dashboard/Profile.tsx
@@ -1,6 +1,5 @@
 import { gql } from '@apollo/client';
 import { useAuthQuery } from '@site/src/helpers/useAuthQuery';
-import { Card } from '@site/src/components/Card';
 import { Button } from '@site/src/components/Button';
 import { usePrivy } from '@privy-io/react-auth';
 import { Copy } from 'lucide-react';

--- a/src/modules/Dashboard/SignInButton.tsx
+++ b/src/modules/Dashboard/SignInButton.tsx
@@ -58,7 +58,7 @@ export function SignInButton() {
       ]}
     />
   ) : (
-    <Button height="h-8" textSize="text-[12px]" type="button" variant="primary" onClick={login}>
+    <Button height="h-8" textSize="text-[14px]" type="button" variant="primary" onClick={login}>
       Sign in
     </Button>
   );

--- a/src/modules/Dashboard/SignInButton.tsx
+++ b/src/modules/Dashboard/SignInButton.tsx
@@ -40,7 +40,7 @@ export function SignInButton() {
 
   return authenticated ? (
     <DropdownNavbarItem
-      label={user.email.address}
+      label={<span className="text-sm">{user.email.address}</span>}
       items={[
         {
           label: 'Dashboard',
@@ -58,8 +58,8 @@ export function SignInButton() {
       ]}
     />
   ) : (
-    <Button type="button" variant="primary" onClick={login}>
-      Sign In
+    <Button height="h-8" textSize="text-[12px]" type="button" variant="primary" onClick={login}>
+      Sign in
     </Button>
   );
 }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -25,12 +25,11 @@ function Dashboard() {
             </div>
 
             <SignedOut>
-              <p>Please log in or sign up to continue</p>
+              <p>Please sign in to continue.</p>
             </SignedOut>
 
             <SignedIn>
               <div className="flex flex-col gap-8">
-                
                 <Note />
                 <Profile />
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,13 @@
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: {
+          default: '#A387FF',
+        },
+      },
+    },
   },
   plugins: [],
   corePlugins: {


### PR DESCRIPTION
Bunch of styling improvements for our dashboard.
Uniformized the use of our primary purple zapper color, removed unnecessary styling, reduced `sign in` button size & email address dropdown size.
Before: 
<img width="1418" alt="image" src="https://github.com/user-attachments/assets/382051b2-8327-41ff-9f1c-f3c136f30929">

Now : 
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/3977a0a0-c30f-481b-a257-f00a2edfa469">
