### PR TITLE
Reload on new user

### DIFF
--- a/src/modules/Dashboard/SignInButton.tsx
+++ b/src/modules/Dashboard/SignInButton.tsx
@@ -18,7 +18,7 @@ export function SignInButton() {
   const { logout } = useLogout();
 
   const { login } = useLogin({
-    onComplete: async (user) => {
+    onComplete: async (user, isNewUser) => {
       if (user.email) {
         const { data } = await upsertUser({
           variables: {
@@ -30,6 +30,10 @@ export function SignInButton() {
         if (clientId) {
           localStorage.setItem('zapper.clientId', clientId);
         }
+      }
+
+      if (isNewUser) {
+        window.location.reload();
       }
     },
   });


### PR DESCRIPTION
## Description

If a new user goes directly to /dashboard and signs up there is a delay before data is created, hence showing empty apiKey

Interim workaround - force a reload if a new user
