### PR TITLE
refactor(studio): Create standalone sandbox button

### DIFF
--- a/docs/api-intro/human-readable-transactions.md
+++ b/docs/api-intro/human-readable-transactions.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 sidebar_label: Human-Readable Transactions
 ---
 
-import { LinkButton } from '@site/src/components/LinkButton';
+import { SandboxButton } from '@site/src/components/SandboxButton';
 import Link from '@docusaurus/Link';
 
 # Human-Readable Transactions
@@ -82,7 +82,7 @@ query($addresses: [Address!]) {
 ```
 
 
-<LinkButton href="./sandbox" type="primary" buttonCopy="Try in sandbox" />
+<SandboxButton/>
 
 ---
 

--- a/docs/api-intro/onchain-identity.md
+++ b/docs/api-intro/onchain-identity.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 sidebar_label: Onchain Identity
 ---
 
-import { LinkButton } from '@site/src/components/LinkButton';
+import { SandboxButton } from '@site/src/components/SandboxButton';
 import Link from '@docusaurus/Link';
 
 # Onchain Identity
@@ -87,7 +87,7 @@ query($address: Address!) {
 
 ```
 
-<LinkButton href="./sandbox" type="primary" buttonCopy="Try in sandbox" />
+<SandboxButton/>
 
 ---
 

--- a/docs/api-intro/portfolio/app-balances.md
+++ b/docs/api-intro/portfolio/app-balances.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 sidebar_label: App Balances
 ---
 
-import { LinkButton } from '@site/src/components/LinkButton';
+import { SandboxButton } from '@site/src/components/SandboxButton';
 import Link from '@docusaurus/Link';
 
 # App Balances
@@ -84,7 +84,7 @@ Smart accounts like Maker’s `DSProxy` are automatically included in the balanc
 :::
 
 
-  <LinkButton href="../sandbox" type="primary" buttonCopy="Try in sandbox" />
+  <SandboxButton/>
 
   ---
 

--- a/docs/api-intro/portfolio/claimables.md
+++ b/docs/api-intro/portfolio/claimables.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 sidebar_label: Claimables
 ---
 
-import { LinkButton } from '@site/src/components/LinkButton';
+import { SandboxButton } from '@site/src/components/SandboxButton';
 import Link from '@docusaurus/Link';
 
 export const tokenBalancesVars = {
@@ -83,7 +83,7 @@ query Claimables($addresses: [Address!]!) {
 }
 ```
 
-<LinkButton href="../sandbox" type="primary" buttonCopy="Try in sandbox" />
+<SandboxButton />
 
 ---
 

--- a/docs/api-intro/portfolio/nft-balances.md
+++ b/docs/api-intro/portfolio/nft-balances.md
@@ -3,7 +3,7 @@ sidebar_position: 5
 sidebar_label: NFT Balances
 ---
 
-import { LinkButton } from '@site/src/components/LinkButton';
+import { SandboxButton } from '@site/src/components/SandboxButton';
 import Link from '@docusaurus/Link';
 
 # NFT Balances
@@ -60,7 +60,7 @@ query($addresses: [Address!]!, $networks: [Network!]) {
 }
 ```
 
-<LinkButton href="../sandbox" type="primary" buttonCopy="Try in sandbox" />
+<SandboxButton/>
 
 ---
 

--- a/docs/api-intro/portfolio/portfolio-totals.md
+++ b/docs/api-intro/portfolio/portfolio-totals.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 sidebar_label: Portfolio Totals
 ---
 
-import { LinkButton } from '@site/src/components/LinkButton';
+import { SandboxButton } from '@site/src/components/SandboxButton';
 import Link from '@docusaurus/Link';
 
 export const tokenBalancesVars = {
@@ -80,7 +80,7 @@ query($addresses: [Address!]!) {
 
 ```
 
-<LinkButton href="../sandbox" type="primary" buttonCopy="Try in sandbox" />
+<SandboxButton/>
 
 ---
 

--- a/docs/api-intro/portfolio/token-balances.md
+++ b/docs/api-intro/portfolio/token-balances.md
@@ -3,7 +3,7 @@ sidebar_position: 3
 sidebar_label: Token Balances
 ---
 
-import { LinkButton } from '@site/src/components/LinkButton';
+import { SandboxButton } from '@site/src/components/SandboxButton';
 import Link from '@docusaurus/Link';
 
 # Token Balances
@@ -90,7 +90,7 @@ query Portfolio($addresses: [Address!]!) {
 }
 ```
 
-<LinkButton href="../sandbox" type="primary" buttonCopy="Try in sandbox" />
+<SandboxButton/>
 
 ---
 

--- a/docs/api-intro/pricing.md
+++ b/docs/api-intro/pricing.md
@@ -3,7 +3,7 @@ sidebar_position: 10
 sidebar_label: Pricing
 ---
 
-import { LinkButton } from '@site/src/components/LinkButton';
+import { SandboxButton } from '@site/src/components/SandboxButton';
 import Link from '@docusaurus/Link';
 
 # Pricing
@@ -56,7 +56,7 @@ The GraphQL [Sandbox](/docs/api-intro/sandbox) can also be used to test queries 
 Note that it is against the Zapper API [Terms of Service](https://zapper.xyz/docs/api-terms-of-use.pdf) to create multiple API keys with the goal of accumulating free credits.
 
 
-<LinkButton href="/dashboard" type="primary" buttonCopy="Get Started" />
+<SandboxButton/>
 
 ---
 

--- a/src/components/SandboxButton.tsx
+++ b/src/components/SandboxButton.tsx
@@ -1,0 +1,7 @@
+import { LinkButton } from '@site/src/components/LinkButton';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+export const SandboxButton = () => {
+  const sandboxUrl = useBaseUrl('/docs/api-intro/sandbox');
+  return <LinkButton href={sandboxUrl} type="primary" buttonCopy="Try in sandbox" />;
+};


### PR DESCRIPTION
## Description

This creates a new component for the `Try in sandbox` buttons : makes sure we can reuse that button anywhere in our app, without paths breaking.