### PR TITLE
smol(studio): Styling for copy message

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -425,3 +425,22 @@ hr {
   white-space: nowrap;
   animation: fadeInOut 2s ease-in-out;
 }
+
+@keyframes fadeInOut {
+  0% {
+    opacity: 0;
+    transform: translate(0, -50%);
+  }
+  15% {
+    opacity: 1;
+    transform: translate(0, -50%);
+  }
+  85% {
+    opacity: 1;
+    transform: translate(0, -50%);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(10px, -50%);
+  }
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -407,8 +407,21 @@ hr {
 .DocSearch-Hit-content-wrapper {
   padding: 4px 8px !important;
 }
-
-.DocSearch-Button-Placeholder,
-.DocSearch-Button-Keys {
+.DocSearch-Button-Placeholder, .DocSearch-Button-Keys {
   display: none !important;
+ }
+
+ .popup {
+  position: absolute;
+  left: 100%;
+  margin-left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: rgb(31, 41, 55);
+  color: white;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  white-space: nowrap;
+  animation: fadeInOut 2s ease-in-out;
 }

--- a/src/modules/Dashboard/Profile.tsx
+++ b/src/modules/Dashboard/Profile.tsx
@@ -1,12 +1,10 @@
 import { gql } from '@apollo/client';
 import { useAuthQuery } from '@site/src/helpers/useAuthQuery';
 import { Button } from '@site/src/components/Button';
-import { usePrivy } from '@privy-io/react-auth';
 import { Copy } from 'lucide-react';
 import { useState, useEffect } from 'react';
-import styles from '@site/src/pages/index.module.scss';
 
-const Toast = ({ message }) => <div className={styles.popup}>{message}</div>;
+const Toast = ({ message }) => <div className="popup">{message}</div>;
 
 const QUERY = gql`
   query Profile {


### PR DESCRIPTION
### Context
We had a regression where the styling for the copy button was removed, so the `copied` message would show in inside the button. 
This adds back the necessary css.