### PR TITLE
smol(studio): Use zapper API naming instead of Protocol

### DIFF
--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -4,7 +4,7 @@ const privyAppId = process.env.PRIVY_APP_ID || '';
 
 const privyConfig: PrivyClientConfig = {
   appearance: {
-    landingHeader: 'Sign in to Zapper Protocol',
+    landingHeader: 'Sign in to Zapper API',
     theme: 'dark',
   },
 };

--- a/src/modules/Dashboard/Note.tsx
+++ b/src/modules/Dashboard/Note.tsx
@@ -7,7 +7,7 @@ export function Note() {
       <div className="flex items-start gap-3">
         <Info className="h-5 w-5 text-primary-default flex-shrink-0" />
         <p className="text-sm">
-          Welcome to the Zapper Protocol Dashboard. While the API is in alpha, each client may query up to 5,000 credits
+          Welcome to the Zapper API Dashboard. While the API is in alpha, each client may query up to 5,000 credits
           for free, providing at least 1,500 queries to test the API. Please note that query costs may change in the future.
         </p>
       </div>


### PR DESCRIPTION
## Description

This simply changes 2 use of `Zapper Protocol` for `Zapper API`. Name might still change in the future - this is for the time being. 
