### PR TITLE
feat(studio): Add credit pricing tiers & docs

### DIFF
--- a/docs/api-intro/pricing.md
+++ b/docs/api-intro/pricing.md
@@ -49,6 +49,21 @@ The `portfolio` query can be called with one or more of the following fields for
 Each address used in a query counts as a query. If you bundle multiple addresses into a single call the cost = query price multiplied by the # of addresses.
 :::
 
+### Credit Pricing Tiers
+
+We offer volume-based discounts through our tiered pricing system:
+
+| Tier | Credit Range | Price per Credit | Price per 1,000 Credits | Discount |
+|------|--------------|------------------|------------------------|----------|
+| 1 | 0-100,000 | $0.001 | $1.00 | - |
+| 2 | 100,001-500,000 | $0.0008 | $0.80 | 20% |
+| 3 | 500,000+ | $0.0007 | $0.70 | 30% |
+
+For example, purchasing 600,000 credits would cost:
+- First 100,000 credits at $0.001 each
+- Next 400,000 credits at $0.0008 each
+- Final 100,000 credits at $0.0007 each
+
 ### Free Tier
 
 All API clients can use up to 5,000 credits for free. This gives clients at least 1,500 queries without having to purchase credits and can be a great way to try the API.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "docusaurus2-dotenv": "^1.4.0",
     "graphql": "^16.9.0",
     "install": "^0.13.0",
+    "lodash": "^4.17.21",
     "lucide-react": "^0.456.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   install:
     specifier: ^0.13.0
     version: 0.13.0
+  lodash:
+    specifier: ^4.17.21
+    version: 4.17.21
   lucide-react:
     specifier: ^0.456.0
     version: 0.456.0(react@18.3.1)


### PR DESCRIPTION
### Context
This uses the new credits BE endpoint to get the cost of a credits amount. 
Also adds documentation on pricing tiers. 