### PR TITLE
smol(studio): Display points even if never queried with api key

### DIFF
--- a/src/modules/Dashboard/BuyCredits.tsx
+++ b/src/modules/Dashboard/BuyCredits.tsx
@@ -159,7 +159,7 @@ export function BuyCredits() {
   };
 
   const { apiV2PointsRemaining = 0, apiV1PointsRemaining } = data?.apiClientById || {};
-  const displayV2Points = apiV2PointsRemaining < 0 ? GRACE_PERIOD + apiV2PointsRemaining : apiV2PointsRemaining;
+  const displayV2Points = apiV2PointsRemaining <= 0 ? GRACE_PERIOD + apiV2PointsRemaining : apiV2PointsRemaining;
   const isNegativeBalance = apiV2PointsRemaining < 0;
   const disabled = loading || !user;
   const formatPrice = (price) => price.toFixed(2);


### PR DESCRIPTION
## Context
We get remaining credits data by going and fetching the clientId's data in scylla. 
For clients that have never queried our endpoints, they have no data in Scylla : this means we need to fallback for `null` credit data to 0. 

We were already doing this, except we needed to display 0 values as well as negative values as the grace period. This fixed it.