### PR TITLE
smol(studio): Add rounding for amounts smaller than 5$

### DIFF
--- a/src/modules/Dashboard/BuyCredits.tsx
+++ b/src/modules/Dashboard/BuyCredits.tsx
@@ -110,7 +110,7 @@ export function BuyCredits() {
       return MIN_POINTS;
     }
     setErrorMessage('');
-    return Math.floor(numValue / 50) * 50;
+    return Math.floor(numValue / MIN_POINTS) * MIN_POINTS;
   };
 
   const debouncedUpdatePrice = useCallback(


### PR DESCRIPTION
## Description

This rounds off credit amounts so that if a user enters odd numbers such as `5430` credits, it will round off to 5k.