### PR TITLE
dashboard-structure

### DIFF
--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -1,125 +1,62 @@
-import React from 'react';
-import { BuyCredits } from '@site/src/modules/Dashboard/BuyCredits';
-import { Profile } from '@site/src/modules/Dashboard/Profile';
-import { PaymentHistory } from '@site/src/modules/Dashboard/PaymentHistory';
-import { ConsumptionStats } from '@site/src/modules/Dashboard/ConsumptionStats';
-import React, { useState } from 'react';
-import { 
-  IoHomeOutline, 
-  IoStatsChartOutline,
-  IoCardOutline,
-  IoArrowForward
-} from 'react-icons/io5';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-
-export default function Dashboard() {
-  const [activeTab, setActiveTab] = useState('overview');
-  
-  const tabs = [
-    { id: 'overview', label: 'Overview', icon: IoHomeOutline },
-    { id: 'analytics', label: 'Analytics', icon: IoStatsChartOutline },
-    { id: 'credits', label: 'Buy Credits', icon: IoCardOutline }
-  ];
-
-  const quickLinks = [
-    { label: 'Quickstart', href: '/docs/quickstart' },
-    { label: 'API Sandbox', href: '/sandbox' },
-    { label: 'LLM Guide', href: '/docs/llm' },
-    { label: 'Examples', href: '/docs/examples' }
-  ];
-
+export default function DashboardMockup() {
   return (
-    <div className="min-h-screen bg-gray-900 text-white">
+    <div className="min-h-screen bg-white">
       {/* Header */}
-      <div className="border-b border-gray-800 p-4">
+      <div className="border-b p-4">
         <h1 className="text-2xl font-bold">API Dashboard</h1>
       </div>
 
       {/* Main Content */}
       <div className="flex flex-col md:flex-row">
-        {/* Tab Navigation - Mobile (Top) / Desktop (Side) */}
-        <nav className={`
-          md:w-64 md:border-r border-gray-800
-          overflow-x-auto
-          ${activeTab === 'overview' ? 'md:block' : ''}
-        `}>
-          <div className="flex md:flex-col p-4">
-            {tabs.map(tab => {
-              const Icon = tab.icon;
-              return (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`
-                    flex items-center space-x-2 p-2 rounded
-                    whitespace-nowrap
-                    min-w-fit
-                    md:w-full
-                    md:mb-2
-                    mr-2
-                    md:mr-0
-                    ${
-                      activeTab === tab.id 
-                        ? 'bg-[#A387FF] text-white' 
-                        : 'text-gray-400 hover:bg-gray-800'
-                    }
-                  `}
-                >
-                  <Icon size={16} />
-                  <span>{tab.label}</span>
-                </button>
-              );
-            })}
+        {/* Tab Navigation */}
+        <nav className="md:w-64 md:border-r p-4">
+          <div className="flex md:flex-col">
+            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 bg-black text-white">
+              Overview
+            </button>
+            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-gray-100">
+              Analytics
+            </button>
+            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-gray-100">
+              Buy Credits
+            </button>
           </div>
         </nav>
 
-        {/* Tab Content */}
-        <div className="flex-1 p-4 md:p-6">
-          {activeTab === 'overview' && (
-            <div className="space-y-6">
-              <Profile />
+        {/* Tab Content Area */}
+        <div className="flex-1 p-4">
+          {/* Overview Tab Content Mock */}
+          <div className="space-y-6">
+            {/* Profile Section Mock */}
+            <div className="border rounded p-4">
+              <div className="font-bold mb-2">Profile</div>
+              <div className="text-sm text-gray-600">[Profile Content]</div>
+            </div>
 
-              {/* API Key */}
-              <Alert>
-                <AlertTitle>Your API Key</AlertTitle>
-                <AlertDescription>
-                  <code className="bg-gray-800 p-2 rounded block mt-2 overflow-x-auto">
-                    f56d9d54-1b7b-4349-9c0f-8ec7e106e28f
-                  </code>
-                </AlertDescription>
-              </Alert>
+            {/* API Key Section Mock */}
+            <div className="border rounded p-4">
+              <div className="font-bold mb-2">Your API Key</div>
+              <code className="bg-gray-100 p-2 rounded block mt-2">
+                f56d9d54-1b7b-4349-9c0f-8ec7e106e28f
+              </code>
+            </div>
 
-              {/* Quick Links */}
-              <div>
-                <h2 className="text-lg font-semibold mb-4">Quick Links</h2>
-                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-                  {quickLinks.map(link => (
-                    <a
-                      key={link.label}
-                      href={link.href}
-                      className="flex items-center justify-center p-4 bg-gray-800 rounded-lg hover:bg-gray-700 hover:border hover:border-[#A387FF] transition-all"
-                    >
-                      <span>{link.label}</span>
-                      <IoArrowForward className="ml-2" size={16} />
-                    </a>
-                  ))}
-                </div>
+            {/* Stats Preview Mock */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="border rounded p-4">
+                <div className="text-sm text-gray-600">Credits Remaining</div>
+                <div className="text-xl font-bold">9,697</div>
+              </div>
+              <div className="border rounded p-4">
+                <div className="text-sm text-gray-600">Requests Today</div>
+                <div className="text-xl font-bold">245</div>
+              </div>
+              <div className="border rounded p-4">
+                <div className="text-sm text-gray-600">Cost Today</div>
+                <div className="text-xl font-bold">$0.25</div>
               </div>
             </div>
-          )}
-
-          {activeTab === 'analytics' && (
-            <div className="space-y-6">
-              <ConsumptionStats />
-            </div>
-          )}
-
-          {activeTab === 'credits' && (
-            <div className="space-y-6">
-              <BuyCredits />
-              <PaymentHistory />
-            </div>
-          )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -1,4 +1,4 @@
-export default function DashboardMockup() {
+function DashboardMockup() {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -1,4 +1,4 @@
-function DashboardMockup() {
+export default function DashboardMockup() {
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -46,6 +46,25 @@ export default function Dashboard() {
 
         {activeTab === 'overview' && (
           <>
+            {/* Usage Summary */}
+            <div className="bg-[#252A2E] p-4 rounded-lg">
+              <h2 className="text-lg font-semibold mb-3">Usage Summary</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div className="bg-[#32383D] p-4 rounded">
+                  <div className="text-sm text-[#C7D2DA]">Credits Remaining</div>
+                  <div className="text-2xl font-bold">9,697</div>
+                </div>
+                <div className="bg-[#32383D] p-4 rounded">
+                  <div className="text-sm text-[#C7D2DA]">Requests Today</div>
+                  <div className="text-2xl font-bold">245</div>
+                </div>
+                <div className="bg-[#32383D] p-4 rounded">
+                  <div className="text-sm text-[#C7D2DA]">Cost Today</div>
+                  <div className="text-2xl font-bold">$3.31</div>
+                </div>
+              </div>
+            </div>
+
             {/* API Key Section */}
             <div className="bg-[#252A2E] p-4 rounded-lg">
               <h2 className="text-lg font-semibold mb-2">API Key</h2>
@@ -73,39 +92,20 @@ export default function Dashboard() {
                 ))}
               </div>
             </div>
-
-            {/* Usage Summary */}
-            <div className="bg-[#252A2E] p-4 rounded-lg">
-              <h2 className="text-lg font-semibold mb-3">Usage Summary</h2>
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-                <div className="bg-[#32383D] p-4 rounded">
-                  <div className="text-sm text-[#C7D2DA]">Credits Remaining</div>
-                  <div className="text-2xl font-bold">9,697</div>
-                </div>
-                <div className="bg-[#32383D] p-4 rounded">
-                  <div className="text-sm text-[#C7D2DA]">Requests Today</div>
-                  <div className="text-2xl font-bold">245</div>
-                </div>
-                <div className="bg-[#32383D] p-4 rounded">
-                  <div className="text-sm text-[#C7D2DA]">Cost Today</div>
-                  <div className="text-2xl font-bold">$3.31</div>
-                </div>
-              </div>
-            </div>
           </>
         )}
 
         {activeTab === 'analytics' && (
           <div className="bg-[#252A2E] p-4 rounded-lg">
             <h2 className="text-lg font-semibold mb-2">Analytics Content</h2>
-            {/* Add your existing charts here */}
+            {/* Add existing module for charts*/}
           </div>
         )}
 
         {activeTab === 'buy-credits' && (
           <div className="bg-[#252A2E] p-4 rounded-lg">
             <h2 className="text-lg font-semibold mb-2">Buy Credits</h2>
-            {/* Add your existing billing content here */}
+            {/* Add existing module for buy and history*/}
           </div>
         )}
       </div>

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -92,7 +92,6 @@ export default function Dashboard() {
                 </div>
               </div>
             </div>
-<<<<<<< HEAD
           </>
         )}
 
@@ -100,17 +99,7 @@ export default function Dashboard() {
           <div className="bg-[#252A2E] p-4 rounded-lg">
             <h2 className="text-lg font-semibold mb-2">Analytics Content</h2>
             {/* Add existing module for charts here */}
-=======
-          </>
-        )}
-
-        {activeTab === 'analytics' && (
-          <div className="bg-[#252A2E] p-4 rounded-lg">
-            <h2 className="text-lg font-semibold mb-2">Analytics Content</h2>
-            {/* Add your existing charts here */}
->>>>>>> 29dde5e9e7711c9262ebd463891e279f3c2d185f
           </div>
-<<<<<<< HEAD
         )}
 
         {activeTab === 'credits' && (
@@ -119,36 +108,6 @@ export default function Dashboard() {
             {/* Add existing module  here */}
           </div>
         )}
-=======
-        )}
-
-        {activeTab === 'billing' && (
-          <div className="bg-[#252A2E] p-4 rounded-lg">
-            <h2 className="text-lg font-semibold mb-2">Billing Content</h2>
-            {/* Add your existing billing content here */}
-          </div>
-        )}
-
-        {activeTab === 'documentation' && (
-          <div className="space-y-4">
-            <div className="bg-[#252A2E] p-4 rounded-lg">
-              <h2 className="text-lg font-semibold mb-2">Getting Started</h2>
-              {/* Add documentation content */}
-            </div>
-            <div className="bg-[#252A2E] p-4 rounded-lg">
-              <h2 className="text-lg font-semibold mb-2">Example Queries</h2>
-              {/* Add example queries */}
-            </div>
-          </div>
-        )}
-
-        {activeTab === 'settings' && (
-          <div className="bg-[#252A2E] p-4 rounded-lg">
-            <h2 className="text-lg font-semibold mb-2">Settings</h2>
-            {/* Add settings content */}
-          </div>
-        )}
->>>>>>> 29dde5e9e7711c9262ebd463891e279f3c2d185f
       </div>
     </div>
   );

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -92,6 +92,15 @@ export default function Dashboard() {
                 </div>
               </div>
             </div>
+<<<<<<< HEAD
+          </>
+        )}
+
+        {activeTab === 'analytics' && (
+          <div className="bg-[#252A2E] p-4 rounded-lg">
+            <h2 className="text-lg font-semibold mb-2">Analytics Content</h2>
+            {/* Add existing module for charts here */}
+=======
           </>
         )}
 
@@ -99,7 +108,18 @@ export default function Dashboard() {
           <div className="bg-[#252A2E] p-4 rounded-lg">
             <h2 className="text-lg font-semibold mb-2">Analytics Content</h2>
             {/* Add your existing charts here */}
+>>>>>>> 29dde5e9e7711c9262ebd463891e279f3c2d185f
           </div>
+<<<<<<< HEAD
+        )}
+
+        {activeTab === 'credits' && (
+          <div className="bg-[#252A2E] p-4 rounded-lg">
+            <h2 className="text-lg font-semibold mb-2">Buy Credits Module</h2>
+            {/* Add existing module  here */}
+          </div>
+        )}
+=======
         )}
 
         {activeTab === 'billing' && (
@@ -128,6 +148,7 @@ export default function Dashboard() {
             {/* Add settings content */}
           </div>
         )}
+>>>>>>> 29dde5e9e7711c9262ebd463891e279f3c2d185f
       </div>
     </div>
   );

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -1,74 +1,133 @@
-export default function DashboardMockup() {
+import React, { useState } from 'react';
+
+export default function Dashboard() {
+  const [activeTab, setActiveTab] = useState('overview');
+
+  const tabs = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'analytics', label: 'Analytics' },
+    { id: 'billing', label: 'Billing' },
+    { id: 'documentation', label: 'Documentation' },
+    { id: 'settings', label: 'Settings' }
+  ];
+
+  const quickActions = [
+    { label: 'Quickstart' },
+    { label: 'Sandbox' },
+    { label: 'Use with LLMs' },
+    { label: 'Examples' }
+  ];
+
   return (
-    <div className="min-h-screen bg-[#0C1013] text-[#FFFFFF]">
+    <div className="min-h-screen bg-[#0C1013] text-[#FFFFFF] p-6">
       {/* Header */}
-      <div className="border-b border-[#32383D] p-4">
-        <h1 className="text-2xl font-bold">API Dashboard</h1>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold mb-2">API Dashboard</h1>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex space-x-1 mb-6 border-b border-[#32383D]">
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`flex items-center px-4 py-2 space-x-2 ${
+              activeTab === tab.id
+                ? 'border-b-2 border-[#A387FF] text-[#A387FF]'
+                : 'text-[#C7D2DA]'
+            }`}
+          >
+            <span>{tab.label}</span>
+          </button>
+        ))}
       </div>
 
       {/* Main Content */}
-      <div className="flex flex-col md:flex-row">
-        {/* Tab Navigation */}
-        <nav className="md:w-64 md:border-r border-[#32383D] p-4 flex justify-center">
-          <div className="space-y-4">
-            <a href="#" className="flex justify-center p-2 text-[#C7D2DA] hover:text-[#FFFFFF] font-medium">
-              Analytics
-            </a>
-            <div className="flex justify-center">
-              <button className="px-6 py-2 rounded bg-[#A387FF] text-[#0C1013] font-medium">
-                Overview
-              </button>
-            </div>
-            <a href="#" className="flex justify-center p-2 text-[#C7D2DA] hover:text-[#FFFFFF] font-medium">
-              Buy Credits
-            </a>
-          </div>
-        </nav>
-        {/* Tab Content Area */}
-        <div className="flex-1 p-4">
-          {/* Overview Tab Content */}
-          <div className="space-y-6">
+      <div className="space-y-6">
+        {activeTab === 'overview' && (
+          <>
             {/* API Key Section */}
-            <div className="border border-[#32383D] rounded p-4">
-              <div className="font-bold mb-2">Your API Key</div>
-              <code className="bg-[#252A2E] text-[#FFFFFF] p-2 rounded block mt-2">
-                f56d9d54-1b7b-4349-9c0f-8ec7e106e28f
-              </code>
+            <div className="bg-[#252A2E] p-4 rounded-lg">
+              <h2 className="text-lg font-semibold mb-2">API Key</h2>
+              <div className="flex items-center space-x-2">
+                <code className="bg-[#32383D] p-2 rounded flex-1">
+                  f56d9d54-1b7b-4349-9c0f-8ec7e106e28f
+                </code>
+                <button className="p-2 bg-[#A387FF] rounded">
+                  Copy
+                </button>
+              </div>
             </div>
 
-            {/* Quick Links */}
-            <div className="flex flex-wrap justify-center space-x-4 space-y-2 md:space-y-0">
-              <a href="#" className="px-4 py-2 bg-[#A387FF] text-[#0C1013] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
-                Quickstart
-              </a>
-              <a href="#" className="px-4 py-2 bg-[#252A2E] text-[#FFFFFF] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
-                Use with Agents & LLMs
-              </a>
-              <a href="#" className="px-4 py-2 bg-[#252A2E] text-[#FFFFFF] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
-                Pricing
-              </a>
-              <a href="#" className="px-4 py-2 bg-[#252A2E] text-[#FFFFFF] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
-                Sandbox
-              </a>
+            {/* Quick Actions */}
+            <div className="mb-6">
+              <h2 className="text-lg font-semibold mb-3">Quick Actions</h2>
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                {quickActions.map(action => (
+                  <button
+                    key={action.label}
+                    className="flex flex-col items-center p-4 bg-[#252A2E] rounded-lg hover:bg-[#32383D]"
+                  >
+                    <span>{action.label}</span>
+                  </button>
+                ))}
+              </div>
             </div>
 
-            {/* Stats Preview */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div className="border border-[#32383D] rounded p-4">
-                <div className="text-sm text-[#C7D2DA]">Credits Remaining</div>
-                <div className="text-xl font-bold">9,697</div>
+            {/* Usage Summary */}
+            <div className="bg-[#252A2E] p-4 rounded-lg">
+              <h2 className="text-lg font-semibold mb-3">Usage Summary</h2>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div className="bg-[#32383D] p-4 rounded">
+                  <div className="text-sm text-[#C7D2DA]">Credits Remaining</div>
+                  <div className="text-2xl font-bold">9,697</div>
+                </div>
+                <div className="bg-[#32383D] p-4 rounded">
+                  <div className="text-sm text-[#C7D2DA]">Requests Today</div>
+                  <div className="text-2xl font-bold">245</div>
+                </div>
+                <div className="bg-[#32383D] p-4 rounded">
+                  <div className="text-sm text-[#C7D2DA]">Cost Today</div>
+                  <div className="text-2xl font-bold">$3.24</div>
+                </div>
               </div>
-              <div className="border border-[#32383D] rounded p-4">
-                <div className="text-sm text-[#C7D2DA]">Requests Today</div>
-                <div className="text-xl font-bold">245</div>
-              </div>
-              <div className="border border-[#32383D] rounded p-4">
-                <div className="text-sm text-[#C7D2DA]">Cost Today</div>
-                <div className="text-xl font-bold">$0.25</div>
-              </div>
+            </div>
+          </>
+        )}
+
+        {activeTab === 'analytics' && (
+          <div className="bg-[#252A2E] p-4 rounded-lg">
+            <h2 className="text-lg font-semibold mb-2">Analytics Content</h2>
+            {/* Add your existing charts here */}
+          </div>
+        )}
+
+        {activeTab === 'billing' && (
+          <div className="bg-[#252A2E] p-4 rounded-lg">
+            <h2 className="text-lg font-semibold mb-2">Billing Content</h2>
+            {/* Add your existing billing content here */}
+          </div>
+        )}
+
+        {activeTab === 'documentation' && (
+          <div className="space-y-4">
+            <div className="bg-[#252A2E] p-4 rounded-lg">
+              <h2 className="text-lg font-semibold mb-2">Getting Started</h2>
+              {/* Add documentation content */}
+            </div>
+            <div className="bg-[#252A2E] p-4 rounded-lg">
+              <h2 className="text-lg font-semibold mb-2">Example Queries</h2>
+              {/* Add example queries */}
             </div>
           </div>
-        </div>
+        )}
+
+        {activeTab === 'settings' && (
+          <div className="bg-[#252A2E] p-4 rounded-lg">
+            <h2 className="text-lg font-semibold mb-2">Settings</h2>
+            {/* Add settings content */}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -1,0 +1,131 @@
+import Layout from '@theme/Layout';
+import React from 'react';
+import { BuyCredits } from '@site/src/modules/Dashboard/BuyCredits';
+import { Profile } from '@site/src/modules/Dashboard/Profile';
+import { SignedIn } from '@site/src/modules/Dashboard/SignedIn';
+import { SignedOut } from '@site/src/modules/Dashboard/SignedOut';
+import { PaymentHistory } from '@site/src/modules/Dashboard/PaymentHistory';
+import { ConsumptionStats } from '@site/src/modules/Dashboard/ConsumptionStats';
+import { Breadcrumbs } from '@site/src/modules/Dashboard/Breadcrumbs';
+import React, { useState } from 'react';
+import { 
+  IoHomeOutline, 
+  IoStatsChartOutline,
+  IoCardOutline,
+  IoArrowForward
+} from 'react-icons/io5';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+
+export default function Dashboard() {
+  const [activeTab, setActiveTab] = useState('overview');
+  
+  const tabs = [
+    { id: 'overview', label: 'Overview', icon: IoHomeOutline },
+    { id: 'analytics', label: 'Analytics', icon: IoStatsChartOutline },
+    { id: 'credits', label: 'Buy Credits', icon: IoCardOutline }
+  ];
+
+  const quickLinks = [
+    { label: 'Quickstart', href: '/docs/quickstart' },
+    { label: 'API Sandbox', href: '/sandbox' },
+    { label: 'LLM Guide', href: '/docs/llm' },
+    { label: 'Examples', href: '/docs/examples' }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      {/* Header */}
+      <div className="border-b border-gray-800 p-4">
+        <h1 className="text-2xl font-bold">API Dashboard</h1>
+      </div>
+
+      {/* Main Content */}
+      <div className="flex flex-col md:flex-row">
+        {/* Tab Navigation - Mobile (Top) / Desktop (Side) */}
+        <nav className={`
+          md:w-64 md:border-r border-gray-800
+          overflow-x-auto
+          ${activeTab === 'overview' ? 'md:block' : ''}
+        `}>
+          <div className="flex md:flex-col p-4">
+            {tabs.map(tab => {
+              const Icon = tab.icon;
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`
+                    flex items-center space-x-2 p-2 rounded
+                    whitespace-nowrap
+                    min-w-fit
+                    md:w-full
+                    md:mb-2
+                    mr-2
+                    md:mr-0
+                    ${
+                      activeTab === tab.id 
+                        ? 'bg-[#A387FF] text-white' 
+                        : 'text-gray-400 hover:bg-gray-800'
+                    }
+                  `}
+                >
+                  <Icon size={16} />
+                  <span>{tab.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </nav>
+
+        {/* Tab Content */}
+        <div className="flex-1 p-4 md:p-6">
+          {activeTab === 'overview' && (
+            <div className="space-y-6">
+              <Profile />
+
+              {/* API Key */}
+              <Alert>
+                <AlertTitle>Your API Key</AlertTitle>
+                <AlertDescription>
+                  <code className="bg-gray-800 p-2 rounded block mt-2 overflow-x-auto">
+                    f56d9d54-1b7b-4349-9c0f-8ec7e106e28f
+                  </code>
+                </AlertDescription>
+              </Alert>
+
+              {/* Quick Links */}
+              <div>
+                <h2 className="text-lg font-semibold mb-4">Quick Links</h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+                  {quickLinks.map(link => (
+                    <a
+                      key={link.label}
+                      href={link.href}
+                      className="flex items-center justify-center p-4 bg-gray-800 rounded-lg hover:bg-gray-700 hover:border hover:border-[#A387FF] transition-all"
+                    >
+                      <span>{link.label}</span>
+                      <IoArrowForward className="ml-2" size={16} />
+                    </a>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'analytics' && (
+            <div className="space-y-6">
+              <ConsumptionStats />
+            </div>
+          )}
+
+          {activeTab === 'credits' && (
+            <div className="space-y-6">
+              <BuyCredits />
+              <PaymentHistory />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -1,6 +1,6 @@
 export default function DashboardMockup() {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-gray-900 text-white">
       {/* Header */}
       <div className="border-b p-4">
         <h1 className="text-2xl font-bold">API Dashboard</h1>
@@ -14,10 +14,10 @@ export default function DashboardMockup() {
             <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 bg-black text-white">
               Overview
             </button>
-            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-gray-100">
+            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-gray-700">
               Analytics
             </button>
-            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-gray-100">
+            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-gray-700">
               Buy Credits
             </button>
           </div>
@@ -26,50 +26,44 @@ export default function DashboardMockup() {
         <div className="flex-1 p-4">
           {/* Overview Tab Content */}
           <div className="space-y-6">
+            {/* API Key Section */}
+            <div className="border rounded p-4">
+              <div className="font-bold mb-2">Your API Key</div>
+              <code className="bg-gray-800 p-2 rounded block mt-2">
+                f56d9d54-1b7b-4349-9c0f-8ec7e106e28f
+              </code>
+            </div>
+
             {/* Quick Links */}
-            <div className="bg-gray-100 py-4">
+            <div className="bg-gray-800 py-4">
               <div className="container mx-auto flex justify-center space-x-4">
-                <a href="#" className="px-4 py-2 bg-black text-white rounded hover:bg-gray-900">
+                <a href="#" className="px-4 py-2 bg-black text-white rounded hover:bg-gray-700">
                   Quickstart
                 </a>
-                <a href="#" className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
+                <a href="#" className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600">
                   Use with Agents & LLMs
                 </a>
-                <a href="#" className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
+                <a href="#" className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600">
                   Pricing
                 </a>
-                <a href="#" className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
+                <a href="#" className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600">
                   Sandbox
                 </a>
               </div>
             </div>
 
-            {/* Profile Section */}
-            <div className="border rounded p-4">
-              <div className="font-bold mb-2">Profile</div>
-              <div className="text-sm text-gray-600">[Profile Content]</div>
-            </div>
-
-            {/* API Key Section */}
-            <div className="border rounded p-4">
-              <div className="font-bold mb-2">Your API Key</div>
-              <code className="bg-gray-100 p-2 rounded block mt-2">
-                f56d9d54-1b7b-4349-9c0f-8ec7e106e28f
-              </code>
-            </div>
-
             {/* Stats Preview */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div className="border rounded p-4">
-                <div className="text-sm text-gray-600">Credits Remaining</div>
+                <div className="text-sm text-gray-400">Credits Remaining</div>
                 <div className="text-xl font-bold">9,697</div>
               </div>
               <div className="border rounded p-4">
-                <div className="text-sm text-gray-600">Requests Today</div>
+                <div className="text-sm text-gray-400">Requests Today</div>
                 <div className="text-xl font-bold">245</div>
               </div>
               <div className="border rounded p-4">
-                <div className="text-sm text-gray-600">Cost Today</div>
+                <div className="text-sm text-gray-400">Cost Today</div>
                 <div className="text-xl font-bold">$0.25</div>
               </div>
             </div>

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -80,7 +80,7 @@ export default function Dashboard() {
 
             {/* Quick Actions */}
             <div className="mb-6">
-              <h2 className="text-lg font-semibold mb-3">Quick Actions</h2>
+              <h2 className="text-lg font-semibold mb-3">Quick Links</h2>
               <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
                 {quickActions.map(action => (
                   <button

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -10,16 +10,16 @@ export default function DashboardMockup() {
       <div className="flex flex-col md:flex-row">
         {/* Tab Navigation */}
         <nav className="md:w-64 md:border-r border-[#32383D] p-4">
-          <div className="flex md:flex-col">
-            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 bg-[#252A2E] text-[#FFFFFF]">
+          <div className="flex md:flex-col space-x-4 md:space-x-0 md:space-y-4">
+            <button className="p-2 rounded bg-[#A387FF] text-[#0C1013] font-medium">
               Overview
             </button>
-            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-[#32383D]">
+            <a href="#" className="p-2 text-[#C7D2DA] hover:text-[#FFFFFF] font-medium">
               Analytics
-            </button>
-            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-[#32383D]">
+            </a>
+            <a href="#" className="p-2 text-[#C7D2DA] hover:text-[#FFFFFF] font-medium">
               Buy Credits
-            </button>
+            </a>
           </div>
         </nav>
         {/* Tab Content Area */}
@@ -36,16 +36,16 @@ export default function DashboardMockup() {
 
             {/* Quick Links */}
             <div className="flex flex-wrap justify-center space-x-4 space-y-2 md:space-y-0">
-              <a href="#" className="px-4 py-2 bg-[#A387FF] text-[#FFFFFF] rounded hover:bg-[#32383D] flex-1 md:flex-none">
+              <a href="#" className="px-4 py-2 bg-[#A387FF] text-[#0C1013] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
                 Quickstart
               </a>
-              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none">
+              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
                 Use with Agents & LLMs
               </a>
-              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none">
+              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
                 Pricing
               </a>
-              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none">
+              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
                 Sandbox
               </a>
             </div>

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -5,7 +5,7 @@ export default function Dashboard() {
 
   const tabs = [
     { id: 'overview', label: 'Overview' },
-    { id: 'analytics', label: 'Analytics' },
+    { id: 'usage', label: 'Usage' },
     { id: 'buy-credits', label: 'Buy Credits' }
   ];
 
@@ -95,16 +95,16 @@ export default function Dashboard() {
           </>
         )}
 
-        {activeTab === 'analytics' && (
+        {activeTab === 'usage' && (
           <div className="bg-[#252A2E] p-4 rounded-lg">
-            <h2 className="text-lg font-semibold mb-2">Analytics Content</h2>
+            <h2 className="text-lg font-semibold mb-2">Charts</h2>
             {/* Add existing module for charts*/}
           </div>
         )}
 
         {activeTab === 'buy-credits' && (
           <div className="bg-[#252A2E] p-4 rounded-lg">
-            <h2 className="text-lg font-semibold mb-2">Buy Credits</h2>
+            <h2 className="text-lg font-semibold mb-2">Buy Credits & Tx history</h2>
             {/* Add existing module for buy and history*/}
           </div>
         )}

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -13,7 +13,7 @@ export default function Dashboard() {
     { label: 'Quickstart' },
     { label: 'Sandbox' },
     { label: 'Use with LLMs' },
-    { label: 'Examples' }
+    { label: 'Pricing' }
   ];
 
   return (
@@ -87,8 +87,8 @@ export default function Dashboard() {
                   <div className="text-2xl font-bold">245</div>
                 </div>
                 <div className="bg-[#32383D] p-4 rounded">
-                  <div className="text-sm text-[#C7D2DA]">Active Integrations</div>
-                  <div className="text-2xl font-bold">3</div>
+                  <div className="text-sm text-[#C7D2DA]">Cost Today</div>
+                  <div className="text-2xl font-bold">$3.31</div>
                 </div>
               </div>
             </div>

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -9,15 +9,17 @@ export default function DashboardMockup() {
       {/* Main Content */}
       <div className="flex flex-col md:flex-row">
         {/* Tab Navigation */}
-        <nav className="md:w-64 md:border-r border-[#32383D] p-4">
-          <div className="flex md:flex-col space-x-4 md:space-x-0 md:space-y-4">
-            <button className="p-2 rounded bg-[#A387FF] text-[#0C1013] font-medium">
-              Overview
-            </button>
-            <a href="#" className="p-2 text-[#C7D2DA] hover:text-[#FFFFFF] font-medium">
+        <nav className="md:w-64 md:border-r border-[#32383D] p-4 flex justify-center">
+          <div className="space-y-4">
+            <a href="#" className="flex justify-center p-2 text-[#C7D2DA] hover:text-[#FFFFFF] font-medium">
               Analytics
             </a>
-            <a href="#" className="p-2 text-[#C7D2DA] hover:text-[#FFFFFF] font-medium">
+            <div className="flex justify-center">
+              <button className="px-6 py-2 rounded bg-[#A387FF] text-[#0C1013] font-medium">
+                Overview
+              </button>
+            </div>
+            <a href="#" className="flex justify-center p-2 text-[#C7D2DA] hover:text-[#FFFFFF] font-medium">
               Buy Credits
             </a>
           </div>
@@ -39,13 +41,13 @@ export default function DashboardMockup() {
               <a href="#" className="px-4 py-2 bg-[#A387FF] text-[#0C1013] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
                 Quickstart
               </a>
-              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
+              <a href="#" className="px-4 py-2 bg-[#252A2E] text-[#FFFFFF] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
                 Use with Agents & LLMs
               </a>
-              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
+              <a href="#" className="px-4 py-2 bg-[#252A2E] text-[#FFFFFF] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
                 Pricing
               </a>
-              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
+              <a href="#" className="px-4 py-2 bg-[#252A2E] text-[#FFFFFF] rounded hover:bg-[#32383D] flex-1 md:flex-none font-medium">
                 Sandbox
               </a>
             </div>

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -1,12 +1,8 @@
-import Layout from '@theme/Layout';
 import React from 'react';
 import { BuyCredits } from '@site/src/modules/Dashboard/BuyCredits';
 import { Profile } from '@site/src/modules/Dashboard/Profile';
-import { SignedIn } from '@site/src/modules/Dashboard/SignedIn';
-import { SignedOut } from '@site/src/modules/Dashboard/SignedOut';
 import { PaymentHistory } from '@site/src/modules/Dashboard/PaymentHistory';
 import { ConsumptionStats } from '@site/src/modules/Dashboard/ConsumptionStats';
-import { Breadcrumbs } from '@site/src/modules/Dashboard/Breadcrumbs';
 import React, { useState } from 'react';
 import { 
   IoHomeOutline, 

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -22,18 +22,35 @@ export default function DashboardMockup() {
             </button>
           </div>
         </nav>
-
         {/* Tab Content Area */}
         <div className="flex-1 p-4">
-          {/* Overview Tab Content Mock */}
+          {/* Overview Tab Content */}
           <div className="space-y-6">
-            {/* Profile Section Mock */}
+            {/* Quick Links */}
+            <div className="bg-gray-100 py-4">
+              <div className="container mx-auto flex justify-center space-x-4">
+                <a href="#" className="px-4 py-2 bg-black text-white rounded hover:bg-gray-900">
+                  Quickstart
+                </a>
+                <a href="#" className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
+                  Use with Agents & LLMs
+                </a>
+                <a href="#" className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
+                  Pricing
+                </a>
+                <a href="#" className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">
+                  Sandbox
+                </a>
+              </div>
+            </div>
+
+            {/* Profile Section */}
             <div className="border rounded p-4">
               <div className="font-bold mb-2">Profile</div>
               <div className="text-sm text-gray-600">[Profile Content]</div>
             </div>
 
-            {/* API Key Section Mock */}
+            {/* API Key Section */}
             <div className="border rounded p-4">
               <div className="font-bold mb-2">Your API Key</div>
               <code className="bg-gray-100 p-2 rounded block mt-2">
@@ -41,7 +58,7 @@ export default function DashboardMockup() {
               </code>
             </div>
 
-            {/* Stats Preview Mock */}
+            {/* Stats Preview */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div className="border rounded p-4">
                 <div className="text-sm text-gray-600">Credits Remaining</div>

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -6,9 +6,7 @@ export default function Dashboard() {
   const tabs = [
     { id: 'overview', label: 'Overview' },
     { id: 'analytics', label: 'Analytics' },
-    { id: 'billing', label: 'Billing' },
-    { id: 'documentation', label: 'Documentation' },
-    { id: 'settings', label: 'Settings' }
+    { id: 'buy-credits', label: 'Buy Credits' }
   ];
 
   const quickActions = [
@@ -19,31 +17,33 @@ export default function Dashboard() {
   ];
 
   return (
-    <div className="min-h-screen bg-[#0C1013] text-[#FFFFFF] p-6">
-      {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold mb-2">API Dashboard</h1>
-      </div>
-
-      {/* Tabs */}
-      <div className="flex space-x-1 mb-6 border-b border-[#32383D]">
-        {tabs.map(tab => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={`flex items-center px-4 py-2 space-x-2 ${
-              activeTab === tab.id
-                ? 'border-b-2 border-[#A387FF] text-[#A387FF]'
-                : 'text-[#C7D2DA]'
-            }`}
-          >
-            <span>{tab.label}</span>
-          </button>
-        ))}
-      </div>
+    <div className="min-h-screen bg-[#0C1013] text-[#FFFFFF] p-6 flex">
+      {/* Navigation */}
+      <nav className="bg-[#252A2E] p-4 rounded-lg mr-6 hidden sm:block">
+        <div className="space-y-2">
+          {tabs.map(tab => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`flex items-center space-x-2 px-4 py-2 rounded ${
+                activeTab === tab.id
+                  ? 'bg-[#A387FF] text-[#FFFFFF]'
+                  : 'hover:bg-[#32383D] text-[#C7D2DA]'
+              }`}
+            >
+              <span>{tab.label}</span>
+            </button>
+          ))}
+        </div>
+      </nav>
 
       {/* Main Content */}
-      <div className="space-y-6">
+      <div className="flex-1 space-y-6">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold mb-2">API Dashboard</h1>
+        </div>
+
         {activeTab === 'overview' && (
           <>
             {/* API Key Section */}
@@ -87,8 +87,8 @@ export default function Dashboard() {
                   <div className="text-2xl font-bold">245</div>
                 </div>
                 <div className="bg-[#32383D] p-4 rounded">
-                  <div className="text-sm text-[#C7D2DA]">Cost Today</div>
-                  <div className="text-2xl font-bold">$3.24</div>
+                  <div className="text-sm text-[#C7D2DA]">Active Integrations</div>
+                  <div className="text-2xl font-bold">3</div>
                 </div>
               </div>
             </div>
@@ -98,14 +98,14 @@ export default function Dashboard() {
         {activeTab === 'analytics' && (
           <div className="bg-[#252A2E] p-4 rounded-lg">
             <h2 className="text-lg font-semibold mb-2">Analytics Content</h2>
-            {/* Add existing module for charts here */}
+            {/* Add your existing charts here */}
           </div>
         )}
 
-        {activeTab === 'credits' && (
+        {activeTab === 'buy-credits' && (
           <div className="bg-[#252A2E] p-4 rounded-lg">
-            <h2 className="text-lg font-semibold mb-2">Buy Credits Module</h2>
-            {/* Add existing module  here */}
+            <h2 className="text-lg font-semibold mb-2">Buy Credits</h2>
+            {/* Add your existing billing content here */}
           </div>
         )}
       </div>

--- a/src/pages/dashboard-test.tsx
+++ b/src/pages/dashboard-test.tsx
@@ -1,23 +1,23 @@
 export default function DashboardMockup() {
   return (
-    <div className="min-h-screen bg-gray-900 text-white">
+    <div className="min-h-screen bg-[#0C1013] text-[#FFFFFF]">
       {/* Header */}
-      <div className="border-b p-4">
+      <div className="border-b border-[#32383D] p-4">
         <h1 className="text-2xl font-bold">API Dashboard</h1>
       </div>
 
       {/* Main Content */}
       <div className="flex flex-col md:flex-row">
         {/* Tab Navigation */}
-        <nav className="md:w-64 md:border-r p-4">
+        <nav className="md:w-64 md:border-r border-[#32383D] p-4">
           <div className="flex md:flex-col">
-            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 bg-black text-white">
+            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 bg-[#252A2E] text-[#FFFFFF]">
               Overview
             </button>
-            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-gray-700">
+            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-[#32383D]">
               Analytics
             </button>
-            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-gray-700">
+            <button className="p-2 rounded md:w-full md:mb-2 mr-2 md:mr-0 hover:bg-[#32383D]">
               Buy Credits
             </button>
           </div>
@@ -27,43 +27,41 @@ export default function DashboardMockup() {
           {/* Overview Tab Content */}
           <div className="space-y-6">
             {/* API Key Section */}
-            <div className="border rounded p-4">
+            <div className="border border-[#32383D] rounded p-4">
               <div className="font-bold mb-2">Your API Key</div>
-              <code className="bg-gray-800 p-2 rounded block mt-2">
+              <code className="bg-[#252A2E] text-[#FFFFFF] p-2 rounded block mt-2">
                 f56d9d54-1b7b-4349-9c0f-8ec7e106e28f
               </code>
             </div>
 
             {/* Quick Links */}
-            <div className="bg-gray-800 py-4">
-              <div className="container mx-auto flex justify-center space-x-4">
-                <a href="#" className="px-4 py-2 bg-black text-white rounded hover:bg-gray-700">
-                  Quickstart
-                </a>
-                <a href="#" className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600">
-                  Use with Agents & LLMs
-                </a>
-                <a href="#" className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600">
-                  Pricing
-                </a>
-                <a href="#" className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600">
-                  Sandbox
-                </a>
-              </div>
+            <div className="flex flex-wrap justify-center space-x-4 space-y-2 md:space-y-0">
+              <a href="#" className="px-4 py-2 bg-[#A387FF] text-[#FFFFFF] rounded hover:bg-[#32383D] flex-1 md:flex-none">
+                Quickstart
+              </a>
+              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none">
+                Use with Agents & LLMs
+              </a>
+              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none">
+                Pricing
+              </a>
+              <a href="#" className="px-4 py-2 bg-[#252A2E] rounded hover:bg-[#32383D] flex-1 md:flex-none">
+                Sandbox
+              </a>
             </div>
 
             {/* Stats Preview */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div className="border rounded p-4">
-                <div className="text-sm text-gray-400">Credits Remaining</div>
+              <div className="border border-[#32383D] rounded p-4">
+                <div className="text-sm text-[#C7D2DA]">Credits Remaining</div>
                 <div className="text-xl font-bold">9,697</div>
               </div>
-              <div className="border rounded p-4">
-                <div className="text-sm text-gray-400">Requests Today</div>
+              <div className="border border-[#32383D] rounded p-4">
+                <div className="text-sm text-[#C7D2DA]">Requests Today</div>
                 <div className="text-xl font-bold">245</div>
               </div>
-              <div className="border rounded p-4">
-                <div className="text-sm text-gray-400">Cost Today</div>
+              <div className="border border-[#32383D] rounded p-4">
+                <div className="text-sm text-[#C7D2DA]">Cost Today</div>
                 <div className="text-xl font-bold">$0.25</div>
               </div>
             </div>


### PR DESCRIPTION
## Description

super basic wireframe of some quick wins we can make to the dashboard.

goals:
- dont make the dashboard a dead-end (add quick links)
- organize with navigation so user doesn't have to scroll
- add some summary stats so client doesn't have to mental math (credits remaining, queries today, cost usd today)
-avoid scope creep we dont need to go crazy

*need to style it as there are ugly bits and add the modules in the right places

test: https://protocol-docs-git-dashboard-stucture-zapper-fi.vercel.app/dashboard-test