### PR TITLE
smol(studio): Remove actors field from app timeline, add docs for perspective

### DIFF
--- a/docs/api/endpoints/human-readable-transactions/app-timelines.md
+++ b/docs/api/endpoints/human-readable-transactions/app-timelines.md
@@ -240,11 +240,10 @@ If you want to surface tokens, NFTs, accounts, or other onchain items embedded w
 | `descriptionDisplayItems`      | Contains the fields which the variables in `description` make reference to.      | `ActivityFeedDisplayItem!!`       |
 | `transaction`      | Contains onchain information like `nounce` , `hash`, `blockNumber`, `gasPrice` and more.       | `OnChainTransaction!`       |
 | `app`      | The app that is associated with the transaction.     | `Int!`       |
-| `actors`      | The address(s) involved in the transaction, includes the object `account` that can surface data such as `address`, `displayName`,and `avatar`.    | `ActorDisplayItem!`      |
 | `displayName`      | Returns the display name of an address (ENS, Farcaster, Lens, etc.).   | `Int!`       |
 | `timestamp`      | Represents date and time as number of milliseconds from start of UNIX epoch.       | `Timestamp!`       |
 | `perspective`      | The address whose perspective is used in deltas.       | `ActivityPerspective!`       |
-| `perspectiveDelta`      | Object containing different deltas such as `tokenDetlasV2` and `nftDeltasV2`.       | `ActivityAccountDelta!`       |
+| `perspectiveDelta`      | Object containing different deltas such as `tokenDetlasV2` and `nftDeltasV2`. Also contains the `Account` type for the transaction's actor.       | `ActivityAccountDelta!`       |
 | `accountDeltasV2`      | Object containing different deltas such as `tokenDetlasV2` and `nftDeltasV2`.       | `ActivityAccountDelta!`       |
 | `tokenDeltasV2`      | Returns info on the tokens transfered in the transaction such as `address`, `amount`, as well as the `token` object with more token specific info.        | `FungibleTokenDeltaConnection!!`       |
 | `nftDeltasV2`      | Returns info on the NFTs transfered in the transaction such as `collectionAddress`, `tokenId`, as well as `attachment` which surfaces other NFT specific fields.       | `NftDeltaConnection!`       |


### PR DESCRIPTION
## Context
Removes the `actors` field from the docs - have been removed from the schema.