### PR TITLE
fix(docs): Keep styles local

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -377,15 +377,6 @@ hr {
   border-radius: 12px;
 }
 
-input {
-  background-color: var(--ifm-input-background);
-  height: 40px;
-  border: none;
-  border-radius: 10px;
-  border: 1px solid var(--ifm-border-color);
-  font-size: 16px;
-}
-
 .problem__section {
   display: flex;
   gap: 32px;

--- a/src/modules/Dashboard/BuyCredits.tsx
+++ b/src/modules/Dashboard/BuyCredits.tsx
@@ -256,13 +256,7 @@ export function BuyCredits() {
               <button
                 type="button"
                 onClick={handleDecrement}
-                className="zapper-btn cursor-pointer py-0 text-2xl font-normal"
-                style={{
-                  width: '40px',
-                  justifyContent: 'center',
-                  display: 'flex',
-                  alignItems: 'center',
-                }}
+                className="zapper-btn cursor-pointer py-0 text-2xl font-normal size-10 grid place-items-center"
               >
                 -
               </button>
@@ -273,19 +267,13 @@ export function BuyCredits() {
                 onChange={handlePointsChange}
                 onBlur={handleBlur}
                 min={MIN_POINTS}
-                className="min-w-28 flex-grow text-center field-sizing-content"
+                className="min-w-28 h-10 flex-grow text-center text-base field-sizing-content border border-solid border-border rounded-lg bg-input"
                 placeholder="Enter credits amount"
               />
               <button
                 type="button"
                 onClick={handleIncrement}
-                className="zapper-btn cursor-pointer py-0 text-2xl font-normal"
-                style={{
-                  width: '40px',
-                  justifyContent: 'center',
-                  display: 'flex',
-                  alignItems: 'center',
-                }}
+                className="zapper-btn cursor-pointer py-0 text-2xl font-normal size-10 grid place-items-center"
               >
                 +
               </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,7 @@ module.exports = {
           light: '#E9EDF2',
           dark: '#252A2E',
         },
+        input: 'var(--ifm-input-background)',
       },
     },
   },


### PR DESCRIPTION
## Description

Styles were too global and had regression on other pages. Keeping it local + refactoring

before
<img width="489" alt="image" src="https://github.com/user-attachments/assets/ca50e35c-1836-4e10-a2b4-d6020ea738b1">

<img width="177" alt="image" src="https://github.com/user-attachments/assets/fd5e585d-9043-4f39-bcc7-7340665d6836">


after
<img width="366" alt="image" src="https://github.com/user-attachments/assets/4bca188f-2694-4c22-bfac-441f038ef751">

<img width="184" alt="image" src="https://github.com/user-attachments/assets/bf3d8aba-a471-464d-bae4-3219a52d1ad6">

