### PR TITLE
smol(studio): Use Vite instead of create-react for react quick start

### DIFF
--- a/docs/api/api.mdx
+++ b/docs/api/api.mdx
@@ -34,7 +34,7 @@ The API key must be base64 encoded for all requests.
 
 #### Setup
 
-1. Create new React project: `npx create-react-app my-app --template typescript`
+1. Create new React project: `npm create vite@latest my-app -- --template react-ts`
 2. Install dependencies: `npm install @apollo/client graphql`
 3. Replace `src/App.tsx` with code below
 4. Replace YOUR_API_KEY with your actual key


### PR DESCRIPTION
## Description
Uses `Vite` instead of `create-react-app` for react's starting guide.